### PR TITLE
Add decode UTF-8 line 341

### DIFF
--- a/instack_undercloud/undercloud.py
+++ b/instack_undercloud/undercloud.py
@@ -338,7 +338,7 @@ def _run_live_command(args, env=None, name=None):
                                stdout=subprocess.PIPE,
                                stderr=subprocess.STDOUT)
     while True:
-        line = process.stdout.readline().decode()
+        line = process.stdout.readline().decode('utf-8')
         if line:
             LOG.info(line.rstrip())
         if line == '' and process.poll() is not None:


### PR DESCRIPTION
My error in CentOS 7:
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/lib/python2.7/site-packages/instack_undercloud/undercloud.py", line 750, in install
    _run_instack(instack_env)
  File "/usr/lib/python2.7/site-packages/instack_undercloud/undercloud.py", line 636, in _run_instack
    _run_live_command(args, instack_env, 'instack')
  File "/usr/lib/python2.7/site-packages/instack_undercloud/undercloud.py", line 341, in _run_live_command
    line = process.stdout.readline().decode()
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 74: ordinal not in range(128)

Get it to work changing line 341:
    line = process.stdout.readline().decode('utf-8')
